### PR TITLE
Enhance example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Now you can detect the encoding via the `CompactEncDet.detect_encoding`,
 which is a thin wrapper around `CompactEncDet::DetectEncoding` and `MimeEncodingName` functions from the C++ library.
 
 > ```ruby
-> file = File.read("unknown-encoding.txt")
+> file = File.read("unknown-encoding.txt", mode: "rb")
 > result = CompactEncDet.detect_encoding(file)
 > result.encoding
 > # => #<Encoding:Windows-1250>


### PR DESCRIPTION
Reading file in binary mode helps with the `ArgumentError: invalid byte sequence in UTF-8` exception.